### PR TITLE
fix tencent parse time error

### DIFF
--- a/tencent.go
+++ b/tencent.go
@@ -24,9 +24,9 @@ import (
 	"net/url"
 	"os"
 	pathutil "path"
+	"time"
 
 	"github.com/tencentyun/cos-go-sdk-v5"
-	"github.com/tencentyun/cos-go-sdk-v5/debug"
 )
 
 // TencentCloudCOSBackend is a storage backend for Tencent Cloud COS
@@ -70,13 +70,6 @@ func NewTencentCloudCOSBackend(bucket string, prefix string, endpoint string) *T
 		Transport: &cos.AuthorizationTransport{
 			SecretID:  secretID,
 			SecretKey: secretKey,
-			Transport: &debug.DebugRequestTransport{
-				RequestHeader: true,
-				// Notice when put a large file and set need the request body, might happend out of memory error.
-				RequestBody:    false,
-				ResponseHeader: true,
-				ResponseBody:   true,
-			},
 		},
 	})
 
@@ -114,7 +107,7 @@ func (t TencentCloudCOSBackend) ListObjects(prefix string) ([]Object, error) {
 			if objectPathIsInvalid(path) {
 				continue
 			}
-			lastModified, _ := http.ParseTime(obj.LastModified)
+			lastModified, _ := time.Parse(time.RFC3339, obj.LastModified)
 			object := Object{
 				Path:         path,
 				Content:      []byte{},


### PR DESCRIPTION
#29 
tencent ListObject LastModified field is a RFC3339 string,
such as 2019-08-29T06:58:42.000Z, can not use http.ParseTime to parse.
Should use time.Parse(time.RFC3339, obj.LastModified) instead.
And should remove transport debug message.