### PR TITLE
Fix for LastModified comparison

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -61,7 +61,7 @@ func GetObjectSliceDiff(os1 []Object, os2 []Object) ObjectSliceDiff {
 		for _, o2 := range os2 {
 			if o1.Path == o2.Path {
 				found = true
-				if !o1.LastModified.Equal(o2.LastModified) {
+				if o2.LastModified.Sub(o1.LastModified) > time.Duration(1*time.Second) {
 					diff.Updated = append(diff.Updated, o2)
 				}
 				break


### PR DESCRIPTION
As some S3 backends (Dell ECS, Ceph…) return milliseconds in LastModified attribute, ignore it when comparing with cached modification time. Fixes issue https://github.com/helm/chartmuseum/issues/152