### PR TITLE
Improve performance with Azure Blob storage by removing unnecessary REST call

### DIFF
--- a/microsoft.go
+++ b/microsoft.go
@@ -87,11 +87,6 @@ func (b MicrosoftBlobBackend) ListObjects(prefix string) ([]Object, error) {
 			continue
 		}
 
-		err = blob.GetProperties(nil)
-		if err != nil {
-			return objects, err
-		}
-
 		object := Object{
 			Path:         path,
 			Content:      []byte{},

--- a/microsoft_test.go
+++ b/microsoft_test.go
@@ -33,7 +33,7 @@ func (suite *MicrosoftTestSuite) SetupSuite() {
 	backend := NewMicrosoftBlobBackend("fake-container-cant-exist-fbce123", "")
 	suite.BrokenAzureBlobBackend = backend
 
-	containerName := os.Getenv("TEST_STORAGE_MICROSOFT_CONTAINER")
+	containerName := os.Getenv("TEST_STORAGE_AZURE_CONTAINER")
 	backend = NewMicrosoftBlobBackend(containerName, "")
 	suite.NoPrefixAzureBlobBackend = backend
 


### PR DESCRIPTION
According to https://docs.microsoft.com/de-de/rest/api/storageservices/list-blobs#response-body 
the Last-Modified property is already being delivered with the ListBlobs call. Thus there 
is no need to iterate over all entries and performing additional rest calls for each blob.

I compared the results before and after GetProperties and LastModified was always the same, hence I believe it can be removed safely.

I tested with 5001 blobs in Azure, here are the results:

Before:
```
λ go test
PASS
ok      github.com/chartmuseum/storage  157.338s
```

After:
```
λ go test
PASS
ok      github.com/chartmuseum/storage  3.723s
```

