### PR TITLE
Add support for a timestamp tolerance when diffing object slices

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -56,13 +56,12 @@ func (object Object) HasExtension(extension string) bool {
 // GetObjectSliceDiff takes two objects slices and returns an ObjectSliceDiff
 func GetObjectSliceDiff(os1 []Object, os2 []Object, timestampTolerance time.Duration) ObjectSliceDiff {
 	var diff ObjectSliceDiff
-
 	for _, o1 := range os1 {
 		found := false
 		for _, o2 := range os2 {
 			if o1.Path == o2.Path {
 				found = true
-				if o2.LastModified.Sub(o1.LastModified) >= timestampTolerance {
+				if o2.LastModified.Sub(o1.LastModified) > timestampTolerance {
 					diff.Updated = append(diff.Updated, o2)
 				}
 				break

--- a/storage.go
+++ b/storage.go
@@ -54,14 +54,15 @@ func (object Object) HasExtension(extension string) bool {
 }
 
 // GetObjectSliceDiff takes two objects slices and returns an ObjectSliceDiff
-func GetObjectSliceDiff(os1 []Object, os2 []Object) ObjectSliceDiff {
+func GetObjectSliceDiff(os1 []Object, os2 []Object, timestampTolerance time.Duration) ObjectSliceDiff {
 	var diff ObjectSliceDiff
+
 	for _, o1 := range os1 {
 		found := false
 		for _, o2 := range os2 {
 			if o1.Path == o2.Path {
 				found = true
-				if !o1.LastModified.Equal(o2.LastModified) {
+				if o2.LastModified.Sub(o1.LastModified) >= timestampTolerance {
 					diff.Updated = append(diff.Updated, o2)
 				}
 				break

--- a/storage_test.go
+++ b/storage_test.go
@@ -193,21 +193,35 @@ func (suite *StorageTestSuite) TestGetObjectSliceDiff() {
 		},
 	}
 	os2 := []Object{}
-	diff := GetObjectSliceDiff(os1, os2)
+	diff := GetObjectSliceDiff(os1, os2, time.Nanosecond)
 	suite.True(diff.Change, "change detected")
 	suite.Equal(diff.Removed, os1, "removed slice populated")
 	suite.Empty(diff.Added, "added slice empty")
 	suite.Empty(diff.Updated, "updated slice empty")
 
 	os2 = append(os2, os1[0])
-	diff = GetObjectSliceDiff(os1, os2)
+	diff = GetObjectSliceDiff(os1, os2, time.Nanosecond)
 	suite.False(diff.Change, "no change detected")
 	suite.Empty(diff.Removed, "removed slice empty")
 	suite.Empty(diff.Added, "added slice empty")
 	suite.Empty(diff.Updated, "updated slice empty")
 
 	os2[0].LastModified = now.Add(1)
-	diff = GetObjectSliceDiff(os1, os2)
+	diff = GetObjectSliceDiff(os1, os2, time.Nanosecond)
+	suite.True(diff.Change, "change detected")
+	suite.Empty(diff.Removed, "removed slice empty")
+	suite.Empty(diff.Added, "added slice empty")
+	suite.Equal(diff.Updated, os2, "updated slice populated")
+
+	os2[0].LastModified = now.Add(time.Second / 2)
+	diff = GetObjectSliceDiff(os1, os2, time.Second)
+	suite.False(diff.Change, "no change detected")
+	suite.Empty(diff.Removed, "removed slice empty")
+	suite.Empty(diff.Added, "added slice empty")
+	suite.Empty(diff.Updated, "updated slice empty")
+
+	os2[0].LastModified = now.Add(time.Second + time.Nanosecond)
+	diff = GetObjectSliceDiff(os1, os2, time.Second)
 	suite.True(diff.Change, "change detected")
 	suite.Empty(diff.Removed, "removed slice empty")
 	suite.Empty(diff.Added, "added slice empty")
@@ -219,11 +233,12 @@ func (suite *StorageTestSuite) TestGetObjectSliceDiff() {
 		Content:      []byte{},
 		LastModified: now,
 	})
-	diff = GetObjectSliceDiff(os1, os2)
+	diff = GetObjectSliceDiff(os1, os2, time.Nanosecond)
 	suite.True(diff.Change, "change detected")
 	suite.Empty(diff.Removed, "removed slice empty")
 	suite.Equal(diff.Added, []Object{os2[1]}, "added slice empty")
 	suite.Empty(diff.Updated, "updated slice empty")
+
 }
 
 func TestStorageTestSuite(t *testing.T) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -193,27 +193,27 @@ func (suite *StorageTestSuite) TestGetObjectSliceDiff() {
 		},
 	}
 	os2 := []Object{}
-	diff := GetObjectSliceDiff(os1, os2, time.Nanosecond)
+	diff := GetObjectSliceDiff(os1, os2, time.Duration(0))
 	suite.True(diff.Change, "change detected")
 	suite.Equal(diff.Removed, os1, "removed slice populated")
 	suite.Empty(diff.Added, "added slice empty")
 	suite.Empty(diff.Updated, "updated slice empty")
 
 	os2 = append(os2, os1[0])
-	diff = GetObjectSliceDiff(os1, os2, time.Nanosecond)
+	diff = GetObjectSliceDiff(os1, os2, time.Duration(0))
 	suite.False(diff.Change, "no change detected")
 	suite.Empty(diff.Removed, "removed slice empty")
 	suite.Empty(diff.Added, "added slice empty")
 	suite.Empty(diff.Updated, "updated slice empty")
 
 	os2[0].LastModified = now.Add(1)
-	diff = GetObjectSliceDiff(os1, os2, time.Nanosecond)
+	diff = GetObjectSliceDiff(os1, os2, time.Duration(0))
 	suite.True(diff.Change, "change detected")
 	suite.Empty(diff.Removed, "removed slice empty")
 	suite.Empty(diff.Added, "added slice empty")
 	suite.Equal(diff.Updated, os2, "updated slice populated")
 
-	os2[0].LastModified = now.Add(time.Second / 2)
+	os2[0].LastModified = now.Add(time.Second)
 	diff = GetObjectSliceDiff(os1, os2, time.Second)
 	suite.False(diff.Change, "no change detected")
 	suite.Empty(diff.Removed, "removed slice empty")
@@ -233,7 +233,7 @@ func (suite *StorageTestSuite) TestGetObjectSliceDiff() {
 		Content:      []byte{},
 		LastModified: now,
 	})
-	diff = GetObjectSliceDiff(os1, os2, time.Nanosecond)
+	diff = GetObjectSliceDiff(os1, os2, time.Duration(0))
 	suite.True(diff.Change, "change detected")
 	suite.Empty(diff.Removed, "removed slice empty")
 	suite.Equal(diff.Added, []Object{os2[1]}, "added slice empty")


### PR DESCRIPTION
Related:
- https://github.com/helm/chartmuseum/issues/152
- https://github.com/helm/chartmuseum/pull/314