### PR TITLE
Rename parameters to indicate direction

### DIFF
--- a/storage_test.go
+++ b/storage_test.go
@@ -192,7 +192,7 @@ func (suite *StorageTestSuite) TestGetObjectSliceDiff() {
 			LastModified: now,
 		},
 	}
-	os2 := []Object{}
+	var os2 []Object
 	diff := GetObjectSliceDiff(os1, os2, time.Duration(0))
 	suite.True(diff.Change, "change detected")
 	suite.Equal(diff.Removed, os1, "removed slice populated")


### PR DESCRIPTION
When I first saw the signature of `GetObjectSliceDiff`, I was not sure which slice of objects is old and which is new. I think renaming them as `prev` and `curr` will clearly indicate it.