### PR TITLE
Add support for Swift V1 Auth

### DIFF
--- a/.codefresh/master.yml
+++ b/.codefresh/master.yml
@@ -4,5 +4,15 @@ steps:
     image: golang:1.14
     working_directory: /go/src/github.com/chartmuseum
     commands:
+      - export TEST_STORAGE_OPENSTACK_CONTAINER=gotestcontainer
+      - export ST_AUTH=http://swift_aio:8080/auth/v1.0
+      - export ST_USER=test:tester
+      - export ST_KEY=testing
       - ln -s /codefresh/volume/${{CF_REPO_NAME}} storage && cd storage
       - make ci-setup testcloud
+    services:
+      composition:
+        swift_aio:
+          image: bouncestorage/swift-aio
+          ports:
+            - 8080

--- a/openstack_test.go
+++ b/openstack_test.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"testing"
 
+	osContainers "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
+
 	"github.com/stretchr/testify/suite"
 )
 
@@ -55,17 +57,18 @@ func (suite *OpenstackTestSuite) SetupSuite() {
 
 	data := []byte("some object")
 	path := "deleteme.txt"
-
 	for _, backend := range suite.NoPrefixOpenstackOSBackend {
-		err := backend.PutObject(path, data)
-		suite.Nil(err, "no error putting deleteme.txt using openstack backend")
+		_, err := osContainers.Create(backend.Client, osContainer, nil).Extract()
+		suite.Nil(err, "error creating container %s: %v", osContainer, err)
+		err = backend.PutObject(path, data)
+		suite.Nil(err, "error putting deleteme.txt using openstack backend")
 	}
 }
 
 func (suite *OpenstackTestSuite) TearDownSuite() {
 	for _, backend := range suite.NoPrefixOpenstackOSBackend {
 		err := backend.DeleteObject("deleteme.txt")
-		suite.Nil(err, "no error deleting deleteme.txt using Openstack backend")
+		suite.Nil(err, "error deleting deleteme.txt using Openstack backend")
 	}
 }
 

--- a/openstack_test.go
+++ b/openstack_test.go
@@ -25,54 +25,79 @@ import (
 
 type OpenstackTestSuite struct {
 	suite.Suite
-	BrokenOpenstackOSBackend   *OpenstackOSBackend
-	NoPrefixOpenstackOSBackend *OpenstackOSBackend
+	BrokenOpenstackOSBackend   []*OpenstackOSBackend
+	NoPrefixOpenstackOSBackend []*OpenstackOSBackend
 }
 
 func (suite *OpenstackTestSuite) SetupSuite() {
 	osRegion := os.Getenv("TEST_STORAGE_OPENSTACK_REGION")
-
-	backend := NewOpenstackOSBackend("fake-container-cant-exist-fbce123", "", osRegion, "")
-	suite.BrokenOpenstackOSBackend = backend
-
 	osContainer := os.Getenv("TEST_STORAGE_OPENSTACK_CONTAINER")
-	backend = NewOpenstackOSBackend(osContainer, "", osRegion, "")
-	suite.NoPrefixOpenstackOSBackend = backend
+
+	if os.Getenv("OS_AUTH_URL") != "" && osRegion != "" {
+		backend := NewOpenstackOSBackend("fake-container-cant-exist-fbce123", "", osRegion, "")
+		suite.BrokenOpenstackOSBackend = append(suite.BrokenOpenstackOSBackend, backend)
+
+		backend = NewOpenstackOSBackend(osContainer, "", osRegion, "")
+		suite.NoPrefixOpenstackOSBackend = append(suite.NoPrefixOpenstackOSBackend, backend)
+	} else {
+		suite.T().Log("Skipping OpenStack Swift tests due to missing ENV vars.")
+	}
+
+	if os.Getenv("ST_AUTH") != "" {
+		backend := NewOpenstackOSBackendV1Auth("fake-container-cant-exist-fbce123", "", "")
+		suite.BrokenOpenstackOSBackend = append(suite.BrokenOpenstackOSBackend, backend)
+
+		backend = NewOpenstackOSBackendV1Auth(osContainer, "", "")
+		suite.NoPrefixOpenstackOSBackend = append(suite.NoPrefixOpenstackOSBackend, backend)
+	} else {
+		suite.T().Log("Skipping Swift TempAuth (V1 Auth) tests due to missing ENV vars.")
+	}
 
 	data := []byte("some object")
 	path := "deleteme.txt"
 
-	err := suite.NoPrefixOpenstackOSBackend.PutObject(path, data)
-	suite.Nil(err, "no error putting deleteme.txt using openstack backend")
+	for _, backend := range suite.NoPrefixOpenstackOSBackend {
+		err := backend.PutObject(path, data)
+		suite.Nil(err, "no error putting deleteme.txt using openstack backend")
+	}
 }
 
 func (suite *OpenstackTestSuite) TearDownSuite() {
-	err := suite.NoPrefixOpenstackOSBackend.DeleteObject("deleteme.txt")
-	suite.Nil(err, "no error deleting deleteme.txt using Openstack backend")
+	for _, backend := range suite.NoPrefixOpenstackOSBackend {
+		err := backend.DeleteObject("deleteme.txt")
+		suite.Nil(err, "no error deleting deleteme.txt using Openstack backend")
+	}
 }
 
 func (suite *OpenstackTestSuite) TestListObjects() {
-	_, err := suite.BrokenOpenstackOSBackend.ListObjects("")
-	suite.NotNil(err, "cannot list objects with bad container")
+	for _, backend := range suite.BrokenOpenstackOSBackend {
+		_, err := backend.ListObjects("")
+		suite.NotNil(err, "cannot list objects with bad container")
+	}
 
-	_, err = suite.NoPrefixOpenstackOSBackend.ListObjects("")
-	suite.Nil(err, "can list objects with good container, no prefix")
+	for _, backend := range suite.NoPrefixOpenstackOSBackend {
+		_, err := backend.ListObjects("")
+		suite.Nil(err, "can list objects with good container, no prefix")
+	}
 }
 
 func (suite *OpenstackTestSuite) TestGetObject() {
-	_, err := suite.BrokenOpenstackOSBackend.GetObject("this-file-cannot-possibly-exist.tgz")
-	suite.NotNil(err, "cannot get objects with bad container")
+	for _, backend := range suite.BrokenOpenstackOSBackend {
+		_, err := backend.GetObject("this-file-cannot-possibly-exist.tgz")
+		suite.NotNil(err, "cannot get objects with bad container")
+	}
 }
 
 func (suite *OpenstackTestSuite) TestPutObject() {
-	err := suite.BrokenOpenstackOSBackend.PutObject("this-file-will-not-upload.txt", []byte{})
-	suite.NotNil(err, "cannot put objects with bad container")
+	for _, backend := range suite.BrokenOpenstackOSBackend {
+		err := backend.PutObject("this-file-will-not-upload.txt", []byte{})
+		suite.NotNil(err, "cannot put objects with bad container")
+	}
 }
 
-func TestOpenstackStorageTestSuite(t *testing.T) {
+func TestOpenstackOSStorageTestSuite(t *testing.T) {
 	if os.Getenv("TEST_CLOUD_STORAGE") == "1" &&
-		os.Getenv("TEST_STORAGE_OPENSTACK_CONTAINER") != "" &&
-		os.Getenv("TEST_STORAGE_OPENSTACK_REGION") != "" {
+		os.Getenv("TEST_STORAGE_OPENSTACK_CONTAINER") != "" {
 		suite.Run(t, new(OpenstackTestSuite))
 	}
 }


### PR DESCRIPTION
gophercloud's `AuthOptionsFromEnv()` does not support Swift V1 Auth[1] directly.
I added NewOpenstackOSBackendV1Auth to support that.

The second commit tries to add running test for Swift V1 Auth in CI but I must admit that I have no experience with codefresh and have not tested that  change yet.

[1] https://www.swiftstack.com/docs/cookbooks/swift_usage/auth.html#v1-auth