### PR TITLE
fix: Set local directory perms to 774

### DIFF
--- a/local.go
+++ b/local.go
@@ -44,7 +44,7 @@ func (b LocalFilesystemBackend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
 	files, err := ioutil.ReadDir(pathutil.Join(b.RootDirectory, prefix))
 	if err != nil {
-		if os.IsNotExist(err) {  // OK if the directory doesnt exist yet
+		if os.IsNotExist(err) { // OK if the directory doesnt exist yet
 			err = nil
 		}
 		return objects, err
@@ -84,7 +84,14 @@ func (b LocalFilesystemBackend) PutObject(path string, content []byte) error {
 	_, err := os.Stat(folderPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			err := os.MkdirAll(folderPath, 0777)
+			err := os.MkdirAll(folderPath, 0774)
+			if err != nil {
+				return err
+			}
+			// os.MkdirAll set the dir permissions before the umask
+			// we need to use os.Chmod to ensure the permissions of the created directory are 774
+			// because the default umask will prevent that and cause the permissions to be 755
+			err = os.Chmod(folderPath, 0774)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes https://github.com/helm/chartmuseum/issues/524.

In order to support using `securityContext.fsGroup` to allow reading/writing charts to a directory on an NFS for example and not setting the owner to `1000` (to limit other users with that UID from having access), we can create the directories with `774` permissions. But we have to use `os.Chmod` in order to set the correct perms due to `os.MkdirAll` applying permissions before the umask (defaults directory permissions to `755`).

@jdolitsky Based on the code, the intention here was to set the directory permissions to `777`. I could keep that permission level and just apply the `os.Chmod` with that but I think denying `others` to write to the chart directory seems desirable. what do you think? There might be some context I'm missing here 👀 