### PR TITLE
Add atomic writes to local backend

### DIFF
--- a/storage_test.go
+++ b/storage_test.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ type StorageTestSuite struct {
 
 func (suite *StorageTestSuite) setupStorageBackends() {
 	timestamp := time.Now().Format("20060102150405")
-	suite.TempDirectory = fmt.Sprintf("../../.test/storage-storage/%s", timestamp)
+	suite.TempDirectory = filepath.Join(".test", timestamp)
 	suite.StorageBackends = make(map[string]Backend)
 	suite.StorageBackends["LocalFilesystem"] = Backend(NewLocalFilesystemBackend(suite.TempDirectory))
 


### PR DESCRIPTION
Fixes #527

Also I noticed the tests were writing to `../../.test` which is outside the repo's directory when you run `make test`, so I moved that path back to `./.test`.