### PR TITLE
fix 4MB index-cache.yaml limit with Azure Blob Storage

### DIFF
--- a/microsoft.go
+++ b/microsoft.go
@@ -165,7 +165,7 @@ func (b MicrosoftBlobBackend) PutObject(path string, content []byte) error {
 	return err
 }
 
-func writeToBlob(context []byte, blobRef *microsoft_storage.Blob) error {
+func writeToBlob(content []byte, blobRef *microsoft_storage.Blob) error {
 	for offset := 0; offset < len(context); offset += maxChunkSize {
 		chunkSize := maxChunkSize
 		if offset+chunkSize > len(context) {

--- a/microsoft.go
+++ b/microsoft.go
@@ -166,12 +166,12 @@ func (b MicrosoftBlobBackend) PutObject(path string, content []byte) error {
 }
 
 func writeToBlob(content []byte, blobRef *microsoft_storage.Blob) error {
-	for offset := 0; offset < len(context); offset += maxChunkSize {
+	for offset := 0; offset < len(content); offset += maxChunkSize {
 		chunkSize := maxChunkSize
-		if offset+chunkSize > len(context) {
-			chunkSize = len(context) - offset
+		if offset+chunkSize > len(content) {
+			chunkSize = len(content) - offset
 		}
-		if err := blobRef.AppendBlock(context[offset:offset+chunkSize], nil); err != nil {
+		if err := blobRef.AppendBlock(content[offset:offset+chunkSize], nil); err != nil {
 			return err
 		}
 	}

--- a/microsoft_test.go
+++ b/microsoft_test.go
@@ -89,6 +89,17 @@ func (suite *MicrosoftTestSuite) TestPutObject() {
 	suite.NotNil(err, "cannot put objects with bad bucket")
 }
 
+func (suite *MicrosoftTestSuite) TestPutObjectGreaterThan4MB() {
+	data := make([]byte, 2*maxChunkSize)
+	for i := 0; i < 2*maxChunkSize; i++ {
+		data[i] = byte(i)
+	}
+	err := suite.NoPrefixAzureBlobBackend.PutObject("this-file-created-for-test.txt", data)
+	suite.Nil(err, "can put objects with good bucket, no prefix")
+	// clean up
+	suite.NoPrefixAzureBlobBackend.DeleteObject("this-file-created-for-test.txt")
+}
+
 func TestAzureStorageTestSuite(t *testing.T) {
 	if os.Getenv("TEST_CLOUD_STORAGE") == "1" &&
 		os.Getenv("TEST_STORAGE_AZURE_CONTAINER") != "" {


### PR DESCRIPTION
Currently, this implementation does not use the azure API's chunked upload, so we will always only be able to upload blobs smaller than 4MB. This PR adds chunked uploads that allow more than 4MB.

Ref: https://learn.microsoft.com/en-us/rest/api/storageservices/append-block, limited by request header Content-Length


