### PR TITLE
chore: use std lib context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.35
 	go.etcd.io/etcd/client/pkg/v3 v3.5.4
 	go.etcd.io/etcd/client/v3 v3.5.4
-	golang.org/x/net v0.1.0
 	google.golang.org/api v0.82.0
 )
 
@@ -57,6 +56,7 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect

--- a/google.go
+++ b/google.go
@@ -17,11 +17,11 @@ limitations under the License.
 package storage
 
 import (
+	"context"
 	"io/ioutil"
 	pathutil "path"
 
 	"cloud.google.com/go/storage"
-	"golang.org/x/net/context"
 	"google.golang.org/api/iterator"
 )
 


### PR DESCRIPTION
drop direct dependency on golang.org/x/net and use standard lib context module