### PR TITLE
Allow set S3ForcePathStyle

### DIFF
--- a/amazon.go
+++ b/amazon.go
@@ -81,7 +81,7 @@ func NewAmazonS3BackendWithOptions(bucket string, prefix string, region string, 
 		client = &http.Client{Transport: tr}
 	}
 	s3ForcePathStyle := endpoint != ""
-	if options.S3ForcePathStyle != nil {
+	if options != nil && options.S3ForcePathStyle != nil {
 		s3ForcePathStyle = *options.S3ForcePathStyle
 	}
 	service := s3.New(session.New(), &aws.Config{

--- a/amazon.go
+++ b/amazon.go
@@ -18,17 +18,17 @@ package storage
 
 import (
 	"bytes"
+	"io/ioutil"
+	pathutil "path"
+	"strings"
+	"net/http"
 	"crypto/tls"
+	"os"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"io/ioutil"
-	"net/http"
-	"os"
-	pathutil "path"
-	"strings"
 )
 
 // AmazonS3Backend is a storage backend for Amazon S3

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chartmuseum/storage
+module github.com/warjiang/storage
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/warjiang/storage
+module github.com/chartmuseum/storage
 
 go 1.17
 


### PR DESCRIPTION
Chartmuseum is a awssome tool to help us maintain and manage internal charts 👍 .

At the same time, chartmuseum provides support for cloud vendors' s3 storage. The keypoint is the chartmuseum/storage library.

Amazon S3 storage is the de facto object storage standard, and many cloud vendors provide S3-compatible object storage interfaces. As the storage interface of chartmuseum, the chartmuseum/storage library is compatible with s3 storage. When initializing the s3 client internally, if a non-empty endpoint is passed in, `S3ForcePathStyle` will be set to true.

```go
service := s3.New(session.New(), &aws.Config{
    HTTPClient:       client,
    Region:           aws.String(region),
    Endpoint:         aws.String(endpoint),
    DisableSSL:       aws.Bool(strings.HasPrefix(endpoint, "http://")),
    S3ForcePathStyle: aws.Bool(endpoint != ""),
})
```

We are using S3-compatible storage provided by a startup cloud vendor. This cloud vendor has disabled the **path style** access method and forces us to use the **virtual hosted** access method. In this case, we need to set the`endpoint` and set the `S3ForcePathStyle` field to false
