### PR TITLE
fix(amazon): use session.NewSession so IRSA credentials are resolved

### DIFF
--- a/amazon.go
+++ b/amazon.go
@@ -50,7 +50,7 @@ func NewAmazonS3Backend(bucket string, prefix string, region string, endpoint st
 		}
 		client = &http.Client{Transport: tr}
 	}
-	service := s3.New(session.New(), &aws.Config{
+	service := s3.New(session.Must(session.NewSession()), &aws.Config{
 		HTTPClient:       client,
 		Region:           aws.String(region),
 		Endpoint:         aws.String(endpoint),
@@ -84,7 +84,7 @@ func NewAmazonS3BackendWithOptions(bucket string, prefix string, region string, 
 	if options != nil && options.S3ForcePathStyle != nil {
 		s3ForcePathStyle = *options.S3ForcePathStyle
 	}
-	service := s3.New(session.New(), &aws.Config{
+	service := s3.New(session.Must(session.NewSession()), &aws.Config{
 		HTTPClient:       client,
 		Region:           aws.String(region),
 		Endpoint:         aws.String(endpoint),
@@ -111,7 +111,7 @@ func NewAmazonS3BackendWithCredentials(bucket string, prefix string, region stri
 		}
 		client = &http.Client{Transport: tr}
 	}
-	service := s3.New(session.New(), &aws.Config{
+	service := s3.New(session.Must(session.NewSession()), &aws.Config{
 		HTTPClient:       client,
 		Credentials:      credentials,
 		Region:           aws.String(region),


### PR DESCRIPTION
## What

Replace the deprecated `session.New()` with `session.Must(session.NewSession())` in the three S3 backend constructors.

## Why

`session.New()` routes through `deprecatedNewSession`, which sets `cfg.Credentials = defaults.CredChain(...)`. That chain is fixed to `EnvProvider`, `SharedCredentialsProvider` and `RemoteCredProvider` — it has no web identity provider, so a pod running with IRSA on EKS fails with:

```
NoCredentialProviders: no valid providers in chain. Deprecated.
```

even though `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are correctly injected.

`session.NewSession()` uses `resolveCredentials`, which handles the web identity case explicitly (`aws/session/credentials.go`, the `len(envCfg.WebIdentityTokenFilePath) != 0` branch). `WebIdentityTokenFilePath` is populated unconditionally from the environment in `envConfigLoad`, so no `AWS_SDK_LOAD_CONFIG` is required.

This complements #907, which added EKS Pod Identity support: Pod Identity works because `RemoteCredProvider` is in the deprecated chain, but IRSA is not reachable from it.

## Notes

Everything else is unchanged: the per-call `aws.Config` still overrides region, endpoint and credentials, so `NewAmazonS3BackendWithCredentials` behaves exactly as before. `amazon.go` is left unformatted on purpose, matching 62f6224b.

Verified with `go build ./...` and `go vet ./...`. The test suite is integration-only and needs live buckets, so it was not run.